### PR TITLE
Add ThreadPool to limit threads usage

### DIFF
--- a/lib/rocketman.rb
+++ b/lib/rocketman.rb
@@ -1,3 +1,4 @@
+require 'rocketman/pool.rb'
 require 'rocketman/registry.rb'
 require 'rocketman/event.rb'
 require 'rocketman/producer.rb'

--- a/lib/rocketman/event.rb
+++ b/lib/rocketman/event.rb
@@ -10,11 +10,9 @@ module Rocketman
     def notify_consumers
       consumers = Rocketman::Registry.instance.get_consumers_for(@event)
 
-      threads = consumers.reduce([]) do |memo, (consumer, action)|
-        memo << Thread.new { consumer.instance_exec(@payload, &action) }
+      consumers.each do |consumer, action|
+        consumer.instance_exec(@payload, &action)
       end
-
-      threads.each { |t| t.join } if @test == true
     end
   end
 end

--- a/lib/rocketman/pool.rb
+++ b/lib/rocketman/pool.rb
@@ -1,0 +1,38 @@
+require 'singleton'
+
+module Rocketman
+  class Pool
+    include Singleton
+
+    def initialize
+      worker_count = 5 # TODO: Refactor to get from config
+      latency = 3 # TODO: Refactor to get from config
+
+      @latency = latency
+      @jobs = Queue.new
+      @workers = []
+
+      worker_count.times do
+        @workers << spawn_worker
+      end
+
+      # spawn_supervisor # TODO: Write a supervisor to monitor workers health, and restart if necessary
+    end
+
+    def schedule(&job)
+      @jobs << job
+    end
+
+    private
+
+    def spawn_worker
+      Thread.new do
+        loop do
+          job = @jobs.pop
+          job.call
+          sleep @latency
+        end
+      end
+    end
+  end
+end

--- a/lib/rocketman/producer.rb
+++ b/lib/rocketman/producer.rb
@@ -2,7 +2,7 @@ module Rocketman
   module Producer
     def emit(event, **payload)
       event = Rocketman::Event.new(event, payload)
-      event.notify_consumers
+      Rocketman::Pool.instance.schedule { event.notify_consumers }
     end
   end
 end

--- a/spec/rocketman_spec.rb
+++ b/spec/rocketman_spec.rb
@@ -1,8 +1,4 @@
 RSpec.describe Rocketman do
-  before(:each) do
-    reset_singleton
-  end
-
   describe "Producer" do
     before do
       Producer = Class.new
@@ -97,9 +93,5 @@ RSpec.describe Rocketman do
 
   def class_cleaner(*klasses)
     klasses.each { |klass| Object.send(:remove_const, "#{klass}") if defined? klass }
-  end
-
-  def reset_singleton
-    Singleton.__init__(Rocketman::Registry)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "pry"
 require "rocketman"
+require "support/test_pool.rb"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -8,6 +9,14 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  # Swap it out to a stub implementation because Thread environment is hard to test
+  Rocketman.send(:remove_const, "Pool")
+  Rocketman::Pool = Rocketman::TestPool
+
+  config.before(:each) do
+    Singleton.__init__(Rocketman::Registry)
+  end
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/test_pool.rb
+++ b/spec/support/test_pool.rb
@@ -1,0 +1,11 @@
+module Rocketman
+  class TestPool
+    def self.instance
+      self
+    end
+
+    def self.schedule(&job)
+      job.call
+    end
+  end
+end


### PR DESCRIPTION
With this commit I added a new thread pool called `Rocketman::Pool`.
Currently it's hardcoded to spawn 5 workers, and each worker will pop
off the queue every 3 seconds. I plan to refactor these to be
customizable.

Due to this change in `Thread` strategy, it also required some
refactoring on the testing side of things. Since it's difficult to test
threaded code, I've decided to swap out the implementation of
`Rocketman::Pool` to `Rocketman::TestPool`, which defines the same
interface, except it is not a singleton and does not run asynchronously.

Fixes #1 