### PR TITLE
Refactor Registry to behave like an Adapter

### DIFF
--- a/lib/rocketman/adapters/memory.rb
+++ b/lib/rocketman/adapters/memory.rb
@@ -1,0 +1,33 @@
+require 'singleton'
+
+module Rocketman
+  module Adapter
+    class Memory
+      include Singleton
+
+      def initialize
+        @registry = {}
+      end
+
+      def register_event(event)
+        if @registry[event]
+          return @registry[event]
+        else
+          @registry[event] = {}
+        end
+      end
+
+      def register_consumer(event, consumer, action)
+        @registry[event][consumer] = action
+      end
+
+      def get_consumers_for(event)
+        @registry[event]
+      end
+
+      def event_exists?(event)
+        !@registry[event].nil?
+      end
+    end
+  end
+end

--- a/lib/rocketman/config.rb
+++ b/lib/rocketman/config.rb
@@ -8,11 +8,12 @@ module Rocketman
   end
 
   class Configuration
-    attr_accessor :worker_count, :latency
+    attr_accessor :worker_count, :latency, :backend
 
     def initialize
       @worker_count = 5
       @latency = 3
+      @backend = :memory
     end
   end
 end

--- a/lib/rocketman/consumer.rb
+++ b/lib/rocketman/consumer.rb
@@ -2,14 +2,8 @@ module Rocketman
   module Consumer
     def on_event(event, &action)
       consumer = self
-      Rocketman::Registry.instance.register_event(event)
-      register_consumer(event, consumer, action)
-    end
-
-    private
-
-    def register_consumer(event, consumer, action)
-      Rocketman::Registry.instance.register_consumer(event, consumer, action)
+      Rocketman::Registry.register_event(event)
+      Rocketman::Registry.register_consumer(event, consumer, action)
     end
   end
 end

--- a/lib/rocketman/event.rb
+++ b/lib/rocketman/event.rb
@@ -4,11 +4,11 @@ module Rocketman
       @event = event
       @payload = payload
       @test = payload.fetch(:test, false)
-      Rocketman::Registry.instance.register_event(event)
+      Rocketman::Registry.register_event(event)
     end
 
     def notify_consumers
-      consumers = Rocketman::Registry.instance.get_consumers_for(@event)
+      consumers = Rocketman::Registry.get_consumers_for(@event)
 
       consumers.each do |consumer, action|
         consumer.instance_exec(@payload, &action)

--- a/lib/rocketman/registry.rb
+++ b/lib/rocketman/registry.rb
@@ -1,31 +1,15 @@
-require 'singleton'
+require 'forwardable'
 
 module Rocketman
   class Registry
-    include Singleton
+    extend SingleForwardable
 
-    def initialize
-      @registry = {}
-    end
+    @backend = case Rocketman.configuration.backend
+               when :memory
+                 require 'rocketman/adapters/memory'
+                 Rocketman::Adapter::Memory.instance
+               end
 
-    def register_event(event)
-      if @registry[event]
-        return @registry[event]
-      else
-        @registry[event] = {}
-      end
-    end
-
-    def register_consumer(event, consumer, action)
-      @registry[event][consumer] = action
-    end
-
-    def get_consumers_for(event)
-      @registry[event]
-    end
-
-    def event_exists?(event)
-      !@registry[event].nil?
-    end
+    def_delegators :@backend, :register_consumer, :register_event, :get_consumers_for, :event_exists?
   end
 end

--- a/spec/rocketman_spec.rb
+++ b/spec/rocketman_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Rocketman do
     end
 
     it 'should register event when emitting' do
-      expect { Producer.new.produce }.to change { Rocketman::Registry.instance.event_exists?(:hello) }.from(false).to(true)
+      expect { Producer.new.produce }.to change { Rocketman::Registry.event_exists?(:hello) }.from(false).to(true)
     end
 
     it 'should notify all downstream consumers' do
@@ -60,7 +60,7 @@ RSpec.describe Rocketman do
         end
       end
 
-      expect(Rocketman::Registry.instance.get_consumers_for(:hello).keys).to eq [Consumer]
+      expect(Rocketman::Registry.get_consumers_for(:hello).keys).to include Consumer
     end
 
     it "should run on_event when event is emitted" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require "bundler/setup"
 require "pry"
 require "rocketman"
-require "support/test_pool.rb"
+require "support/test_pool"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -13,10 +13,6 @@ RSpec.configure do |config|
   # Swap it out to a stub implementation because Thread environment is hard to test
   Rocketman.send(:remove_const, "Pool")
   Rocketman::Pool = Rocketman::TestPool
-
-  config.before(:each) do
-    Singleton.__init__(Rocketman::Registry)
-  end
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
This commit implements an adapter pattern for `Registry`, and
subsequently move the current in-memory registry from `Registry` to
`Adapter::Memory`.

By refactoring to this pattern it allows us to plug in different backend
to store the events (e.g: `redis`)