### PR TITLE
Add Redis as a persistence layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 <sub>*yes, I know it says Starman on the image*</sub>
 > *🎶 And I think it's gonna be a long long time 'Till touch down brings me round again to find 🎶*
 
-Rocketman is a gem that introduces Pub-Sub mechanism within Ruby code.
+Rocketman is a gem that introduces Pub-Sub mechanism within your Ruby code.
+
+The main goal of Rocketman is not to replace proper message buses like Redis PubSub/Kafka, but rather be a stepping stone. You can read more about the rationale behind the project down below.
 
 As with all Pub-Sub mechanism, this greatly decouples your upstream producer and downstream consumer, allowing for scalability, and easier refactor when you decide to move Pub-Sub to a separate service.
 
@@ -29,7 +31,7 @@ Or install it yourself as:
 
 Rocketman exposes two module, `Rocketman::Producer` and `Rocketman::Consumer`. They do exactly as what their name implies. All you need to do is `include Rocketman::Producer` and `extend Rocketman::Consumer` into your code.
 
-#### Producer
+### Producer
 Producer exposes one **instance** method to you: `:emit`. `:emit` takes in the event name and an optional payload and publishes it to the consumers. There's nothing more you need to do. The producer do not have to know who its consumers are.
 
 ```ruby
@@ -42,18 +44,9 @@ class Producer
 end
 ```
 
-Note that Producer emit events with threads that run in a thread pool. The default number of worker is 5, and the workers default to checking the job with a 3 seconds interval. You can tweak it to your liking like so:
+Note that Producer emit events with threads that run in a thread pool. The default number of worker is 5, and the workers default to checking the job with a 3 seconds interval. You can tweak these to your liking, refer to the [`Configuration` section](https://github.com/edisonywh/rocketman#configuration) below for more informations.
 
-```ruby
-# config/initializers/rocketman.rb
-
-Rocketman.configure do |config|
-  config.worker_count = 10 # defaults to 5
-  config.latency      = 1  # defaults to 3, unit is :seconds
-end
-```
-
-#### Consumer
+### Consumer
 Consumer exposes a **class** method, `:on_event`. `:on_event` takes in the event name, and also an additional block, which gets executed whenever a message is received. If an additional `payload` is emitted along with the event, you can get access to it in the form of block argument.
 
 ```ruby
@@ -69,7 +62,7 @@ end
 
 Simple isn't it?
 
-##### Consume events from external services
+#### Consume events from external services
 
 If you want to also consume events from external services, you're in luck (well, as long as you're using `Redis` anyway..)
 
@@ -99,15 +92,54 @@ on_event :hello do |payload|
 end
 ```
 
-Notice how it behaves exactly the same as if the events did not come from Redis? :)
+Notice how it behaves exactly the same as if the events did not come from Redis :)
 
 **NOTE**: You should always pass in a **new, dedicated** connection to `Redis` to `Bridge#construct`. This is because `redis.subscribe` will hog the whole Redis connection (not just Ruby process), so `Bridge` expects a dedicated connection for itself.
+
+## Persisting emitted events
+
+By default, the events emitted from your app will be stored in an in-memory `Queue`, which will get processed by Rocketman threaded workers.
+
+However this also means that if your app dies with events still in your job queue, your emitted events which are stored in-memory will be lost.
+
+That is obviously not desirable, so that's why **Rocketman ships with an option to use `Redis` as your backing storage mechanism.**
+
+All you need to do is pass in a `Redis` connection to Rocketman. Refer to the [`Configuration` section below](https://github.com/edisonywh/rocketman#configuration) for more information.
+
+## Configuration
+
+Here are the available options to tweak for Rocketman.
+
+```ruby
+# config/initializers/rocketman.rb
+
+Rocketman.configure do |config|
+  config.worker_count = 10 # defaults to 5
+  config.latency      = 1  # defaults to 3, unit is :seconds
+  config.storage      = Redis.new # defaults to `nil`
+  config.debug        = true # defaults to `false`
+end
+```
+
+Currently `storage` only supports `Redis`, suggestions for alternative backing mechanisms are welcomed.
+
+`debug` mode enables some debugging `puts` statements, and also tweak the `Thread` workers to `abort_on_exception = true`. So if you have failing jobs, this is how you can figure out what's happening inside your workers.
+
+## Why use `Rocketman`, rather than a proper message bus (e.g Redis PubSub/Kafka)?
+
+It is worth noting that `Rocketman` is not meant to be a replacement for the aforementioned projects -- both Redis PubSub and Kafka are battle-tested and I highly encourage to use them if you can.
+
+**But**, `Rocketman` recognizes that it's not an easy task to spin up an external message bus to support event-driven architecture, and that's what it's trying to do - to be a stepping stone for eventual greatness.
+
+Moving onto a event-driven architecture is not an easy task - your team has to agree on a message bus, the DevOps team needs the capacity to manage the message bus, and then what about clustering? failovers?
+
+So what Rocketman offers you is that you can start writing your dream-state event-driven code **today**, and when the time comes and your team has the capacity to move to a different message bus, then it should be a minimal change.
 
 ## Roadmap
 
 Right now events are using a `fire-and-forget` mechanism, which is designed to not cause issue to producers. However, this also means that if a consumer fail to consume an event, it'll be lost forever. **Next thing on the roadmap is look into a retry strategy + persistence mechanism.**
 
-Emitted events are also stored in memory in `Rocketman::Pool`, which means that there's a chance that you'll lose all emitted jobs. **Something to think about is to perhaps move the emitted events/job queue onto a persistent storage, like Redis for example.**
+~~Emitted events are also stored in memory in `Rocketman::Pool`, which means that there's a chance that you'll lose all emitted jobs. Something to think about is to perhaps move the emitted events/job queue onto a persistent storage, like Redis for example.~~ **Redis support is now available!**
 
 The interface could also probably be better defined, as one of the goal of Rocketman is to be the stepping stone before migrating off to a real, proper message queue/pub-sub mechanism like Kafka. **I want to revisit and think about how can we make that transition more seamless.**
 

--- a/lib/rocketman/config.rb
+++ b/lib/rocketman/config.rb
@@ -8,12 +8,13 @@ module Rocketman
   end
 
   class Configuration
-    attr_accessor :worker_count, :latency, :backend
+    attr_accessor :worker_count, :latency, :storage, :debug
 
     def initialize
       @worker_count = 5
       @latency = 3
-      @backend = :memory
+      @storage= nil
+      @debug = false
     end
   end
 end

--- a/lib/rocketman/event.rb
+++ b/lib/rocketman/event.rb
@@ -9,6 +9,8 @@ module Rocketman
     def notify_consumers
       consumers = Rocketman::Registry.get_consumers_for(@event)
 
+      return if consumers.nil? || consumers.empty?
+
       consumers.each do |consumer, action|
         consumer.instance_exec(@payload, &action)
       end

--- a/lib/rocketman/job_queue.rb
+++ b/lib/rocketman/job_queue.rb
@@ -1,0 +1,76 @@
+require 'forwardable'
+require 'json'
+
+module Rocketman
+  class JobQueue
+    extend Forwardable
+
+    QUEUE_KEY = "rocketman".freeze
+
+    def_delegators :@jobs, :<<, :empty?, :size, :clear, :push, :pop
+
+    def initialize
+      @storage = Rocketman.configuration.storage
+      @jobs = get_job_queue
+
+      at_exit { persist_events } if @storage.class.to_s == "Redis"
+    end
+
+    def schedule(job)
+      @jobs << job
+    end
+
+    private
+
+    def get_job_queue
+      case @storage.class.to_s
+      when "Redis"
+        rehydrate_events
+      else
+        Queue.new
+      end
+    end
+
+    def rehydrate_events
+      queue = Queue.new
+
+      if raw_data = @storage.get(QUEUE_KEY)
+        puts "Rehydrating Rocketman events from #{@storage.class}" if Rocketman.configuration.debug
+
+        rehydrate = JSON.restore(raw_data) # For security measure to prevent remote code execution (only allow contents valid in JSON)
+        jobs = Marshal.load(rehydrate)
+        event_count = 0
+
+        until jobs.empty?
+          queue << jobs.shift
+          event_count += 1
+        end
+
+        puts "Rehydrated #{event_count} events from #{@storage.class}" if Rocketman.configuration.debug
+
+        @storage.del(QUEUE_KEY) # After rehydration, delete it off Redis
+      end
+
+      queue
+    end
+
+    def persist_events
+      return if @jobs.empty?
+
+      puts "Persisting Rocketman events to #{@storage.class}" if Rocketman.configuration.debug
+      intermediary = []
+      event_count = 0
+
+      until @jobs.empty?
+        intermediary << @jobs.pop
+        event_count += 1
+      end
+      @jobs.close
+
+      marshalled_json = Marshal.dump(intermediary).to_json # For security measure to prevent remote code execution (only allow contents valid in JSON)
+
+      @storage.set(QUEUE_KEY, marshalled_json)
+      puts "Persisted #{event_count} events to #{@storage.class}" if Rocketman.configuration.debug
+    end
+  end
+end

--- a/lib/rocketman/pool.rb
+++ b/lib/rocketman/pool.rb
@@ -1,15 +1,18 @@
 require 'singleton'
+require 'rocketman/job_queue'
 
 module Rocketman
   class Pool
     include Singleton
+
+    attr_reader :jobs
 
     def initialize
       worker_count = Rocketman.configuration.worker_count
       latency = Rocketman.configuration.latency
 
       @latency = latency
-      @jobs = Queue.new
+      @jobs = Rocketman::JobQueue.new
       @workers = []
 
       worker_count.times do
@@ -19,17 +22,15 @@ module Rocketman
       # spawn_supervisor # TODO: Write a supervisor to monitor workers health, and restart if necessary
     end
 
-    def schedule(&job)
-      @jobs << job
-    end
-
     private
 
     def spawn_worker
+      Thread.abort_on_exception = true if Rocketman.configuration.debug
+
       Thread.new do
         loop do
           job = @jobs.pop
-          job.call
+          job.notify_consumers # Job is an instance of Rocketman::Event
           sleep @latency
         end
       end

--- a/lib/rocketman/producer.rb
+++ b/lib/rocketman/producer.rb
@@ -2,7 +2,7 @@ module Rocketman
   module Producer
     def emit(event, payload = {})
       event = Rocketman::Event.new(event.to_sym, payload)
-      Rocketman::Pool.instance.schedule { event.notify_consumers }
+      Rocketman::Pool.instance.jobs.schedule(event)
     end
   end
 end

--- a/spec/support/test_pool.rb
+++ b/spec/support/test_pool.rb
@@ -4,8 +4,12 @@ module Rocketman
       self
     end
 
-    def self.schedule(&job)
-      job.call
+    def self.jobs
+      self
+    end
+
+    def self.schedule(job)
+      job.notify_consumers
     end
   end
 end


### PR DESCRIPTION
By default, the events emitted from your app will be stored in an
in-memory `Queue`, which will get processed by Rocketman threaded
workers.

However this also means that if your app dies with events still in your
job queue, your emitted events which are stored in-memory will be lost.

That is obviously not desirable, so that's why Rocketman (this commit) ships with an
option to use `Redis` as your backing storage mechanism.